### PR TITLE
Fix cmake regeneration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,19 +1,19 @@
 cmake_minimum_required(VERSION 3.10)
 project(acados_vendor_ros2)
 
+# CMake options
 option(FORCE_BUILD_VENDOR_PKG
   "Build Acados from source, even if system-installed package is available"
   ON
 )
-
 option(BUILD_ACADOS_TEMPLATE
   "Build and install the Python interface ('acados_template' package). Requieres two consecutive builds to be effective!"
   ON
 )
 
-# Default to C++17
+# Setup
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD 17) # Default to C++17
   set(CMAKE_CXX_STANDARD_REQUIRED ON)
 endif()
 
@@ -72,11 +72,22 @@ if(BUILD_TESTING)
   ament_lint_cmake()
   ament_copyright()
   ament_xmllint()
-  # TODO: Extra unit tests ?
+  # TODO(tpoignonec): Extra unit tests ?
   # See https://github.com/ros2/libyaml_vendor/blob/rolling/CMakeLists.txt for an example
 endif()
 
+# Export 'FindAcados.cmake'
 install(DIRECTORY cmake DESTINATION share/${PROJECT_NAME})
+
+# Copy additional cmake utils required by Acados
+install(
+  FILES
+    #${ACADOS_SOURCE_BUILD_DIR}/cmake/FindFortranLibs.cmake # Triggers naming convention warnings...
+    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/FindFortranLibs.cmake
+    ${ACADOS_SOURCE_BUILD_DIR}/cmake/FindOpenBLAS.cmake
+  DESTINATION
+    share/${PROJECT_NAME}/cmake/Modules
+)
 
 # Add empty bin directory (used to download the tera renderer)
 install(DIRECTORY DESTINATION "opt/${PROJECT_NAME}/bin")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,6 @@ set(ACADOS_SOURCE_BUILD_DIR ${CMAKE_BINARY_DIR}/acados_vendor_ros2-prefix/src/ac
 set(ACADOS_PYTHON_INTERFACE_PATH none) # Python package after install, set bellow if package built
 
 if(${BUILD_ACADOS_TEMPLATE})
-  add_custom_target(dummy_target ALL) # To force rebuilding...
   set(ACADOS_PYTHON_INTERFACE_PCK_DIR "${ACADOS_SOURCE_BUILD_DIR}/interfaces/acados_template/acados_template")
   if(EXISTS "${ACADOS_PYTHON_INTERFACE_PCK_DIR}/__init__.py")
     ament_python_install_package(
@@ -51,12 +50,17 @@ if(${BUILD_ACADOS_TEMPLATE})
       '${ACADOS_PYTHON_INTERFACE_PATH}'."
     )
   else()
-      message(
-        WARNING
-        "The Python interface (acados_template) could not be built \
-        because the external project was not yet downloaded!\n \
-        Please re-build the project once again with the cmake arg '-DBUILD_ACADOS_TEMPLATE=ON'!"
-      )
+    # Force a CMAKE regeneration at next 'colcon build' call
+    include("${CMAKE_CURRENT_LIST_DIR}/cmake/force_regenerate.cmake")
+    force_regenerate_at_next_build()
+
+    message(
+      WARNING
+      "The Python interface (acados_template) could not be built \
+      because the external project was not yet downloaded!\n \
+      Please re-build the project once again.\n \
+      Note: if it doesn't work, please try with the cmake arg '-DBUILD_ACADOS_TEMPLATE=ON'!"
+    )
   endif()
 endif()
 ament_environment_hooks("${CMAKE_CURRENT_SOURCE_DIR}/env-hooks/${PROJECT_NAME}.sh.in")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ install(DIRECTORY cmake DESTINATION share/${PROJECT_NAME})
 install(
   FILES
     #${ACADOS_SOURCE_BUILD_DIR}/cmake/FindFortranLibs.cmake # Triggers naming convention warnings...
-    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/FindFortranLibs.cmake
+    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/FindFORTRANLIBS.cmake
     ${ACADOS_SOURCE_BUILD_DIR}/cmake/FindOpenBLAS.cmake
   DESTINATION
     share/${PROJECT_NAME}/cmake/Modules

--- a/README.md
+++ b/README.md
@@ -12,20 +12,18 @@ git clone https://github.com/tpoignonec/acados_vendor_ros2.git
 
 # Download the source and install the c interface (lib "acados")
 cd ..
-colcon build --cmake-args -DBUILD_ACADOS_TEMPLATE=OFF
-# Install the python interface (package "acados_template")
-colcon build --cmake-args -DBUILD_ACADOS_TEMPLATE=ON
+colcon build && colcon build
 ```
-Note that `colcon build` is called twice. 
+Note that `colcon build` is called twice.
 
 > N.B., this is necessary because `ament_vendor(...)` takes effect after the `ament_python_install_package(...)` command.
 However, the later tests for the existence of an `__init__.py` file in the path, hence resulting in an error since the Python package is not yet present.
 
->**TODO:** Allow unique build to avoid downstream build tests failures.
+>**TODO:** Allow unique build to avoid potential downstream build tests failures.
 
 ## Usage
 
-### For a C++ project 
+### For a C++ project
 > `package.xml` :
 ```xml
 ...
@@ -49,7 +47,7 @@ ocp_nlp_plan_t* plan_ptr = ocp_nlp_plan_create(N);
 ...
 ```
 
-### For a Python project 
+### For a Python project
 
 > `package.xml` :
 ```xml
@@ -59,4 +57,4 @@ ocp_nlp_plan_t* plan_ptr = ocp_nlp_plan_create(N);
 ```
 
 > `setup.py` :
-Nothing special. 
+Nothing special.

--- a/cmake/Modules/FindFORTRANLIBS.cmake
+++ b/cmake/Modules/FindFORTRANLIBS.cmake
@@ -54,5 +54,5 @@ if(NOT FORTRAN_LIBRARY)
 endif()
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(FortranLibs FOUND_VAR FortranLibs_FOUND
+find_package_handle_standard_args(FORTRANLIBS FOUND_VAR FORTRANLIBS_FOUND
                                               REQUIRED_VARS FORTRAN_LIBRARY)

--- a/cmake/Modules/FindFortranLibs.cmake
+++ b/cmake/Modules/FindFortranLibs.cmake
@@ -1,0 +1,58 @@
+#
+# Copyright (c) The acados authors.
+#
+# This file is part of acados.
+#
+# The 2-Clause BSD License
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.;
+#
+
+
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+    list(APPEND CMAKE_FIND_LIBRARY_PREFIXES "lib")
+    list(APPEND CMAKE_FIND_LIBRARY_SUFFIXES ".dll")
+endif()
+
+find_library(FORTRAN_LIBRARY NAMES libgfortran.so libgfortran.dylib gfortran
+    HINTS
+        /usr/lib/gcc/x86_64-linux-gnu/*
+        /usr/local/lib/gcc/*
+        /usr/lib/gcc/arm-linux-gnueabihf/* # for Raspbian
+        ${CMAKE_FIND_ROOT_PATH}
+        $ENV{PATH}
+    CMAKE_FIND_ROOT_PATH_BOTH)
+
+if(NOT FORTRAN_LIBRARY)
+    find_library(FORTRAN_LIBRARY gfortran-4 gfortran-3
+        HINTS
+            /usr/lib/gcc/x86_64-linux-gnu/*
+            /usr/local/lib/gcc/*
+            ${CMAKE_FIND_ROOT_PATH}
+            $ENV{PATH}
+        CMAKE_FIND_ROOT_PATH_BOTH)
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(FortranLibs FOUND_VAR FortranLibs_FOUND
+                                              REQUIRED_VARS FORTRAN_LIBRARY)

--- a/cmake/force_regenerate.cmake
+++ b/cmake/force_regenerate.cmake
@@ -6,7 +6,7 @@
 
 function(force_regenerate_at_next_build)
     set( FLAG_FILE_REBUILD ${CMAKE_CURRENT_SOURCE_DIR}/.flag_regenerate_cmake )
-    execute_process ( COMMAND touch ${FLAG_FILE_REBUILD} )
+    execute_process( COMMAND touch ${FLAG_FILE_REBUILD} )
     add_custom_target(regenerate_cmake ALL)
     add_custom_command(
         TARGET  regenerate_cmake

--- a/cmake/force_regenerate.cmake
+++ b/cmake/force_regenerate.cmake
@@ -1,3 +1,9 @@
+# Copyright 2023 ICUBE Laboratory, University of Strasbourg
+# License: Apache License, Version 2.0
+# Author: Thibault Poignonec (tpoignonec@unistra.fr)
+
+# Part of the 'acados_vendor_ros2' package
+
 function(force_regenerate_at_next_build)
     set( FLAG_FILE_REBUILD ${CMAKE_CURRENT_SOURCE_DIR}/.flag_regenerate_cmake )
     execute_process ( COMMAND touch ${FLAG_FILE_REBUILD} )

--- a/cmake/force_regenerate.cmake
+++ b/cmake/force_regenerate.cmake
@@ -1,0 +1,17 @@
+function(force_regenerate_at_next_build)
+    set( FLAG_FILE_REBUILD ${CMAKE_CURRENT_SOURCE_DIR}/.flag_regenerate_cmake )
+    execute_process ( COMMAND touch ${FLAG_FILE_REBUILD} )
+    add_custom_target(regenerate_cmake ALL)
+    add_custom_command(
+        TARGET  regenerate_cmake
+        DEPENDS ${FLAG_FILE_REBUILD}
+        COMMAND rm -f ${FLAG_FILE_REBUILD}
+        COMMENT "The cmake configuration will be regenerated at next build."
+    )
+    set_property(
+        DIRECTORY
+        APPEND
+        PROPERTY CMAKE_CONFIGURE_DEPENDS
+        ${FLAG_FILE_REBUILD}
+    )
+endfunction()

--- a/test/test_acados_c_interface.cpp
+++ b/test/test_acados_c_interface.cpp
@@ -23,8 +23,6 @@
 
 // Test nlp interface
 TEST(test_acados_vendor, test_include_acados_c_template) {
-    ocp_nlp_plan_t* plan_ptr = ocp_nlp_plan_create(10);
-    EXPECT_NE(plan_ptr, nullptr)
+  ocp_nlp_plan_t * plan_ptr = ocp_nlp_plan_create(10);
+  EXPECT_NE(plan_ptr, nullptr)
 }
-
-


### PR DESCRIPTION
Minor fixes mainly:
- use a cmake 'custom_target' to force the regeneration
- the build command becomes `colcon build && colcon build`
- fix the "FindFortranLibs" build warnings
- clean-up and updtate README.md